### PR TITLE
make gradlew executable in android.yml

### DIFF
--- a/project/03-Operations/Handout.md
+++ b/project/03-Operations/Handout.md
@@ -391,6 +391,9 @@ jobs:
         KEYS: ${{ secrets.KEYS }}
       run: echo $KEYS > app/src/main/res/values/keys.xml
 
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
     - name: run tests
       uses: reactivecircus/android-emulator-runner@v2
       with:


### PR DESCRIPTION
I got an error while building with the given yaml code, and the solution mentioned here(https://github.community/t/gradlew-commands-not-working/17181) worked.

So I have added that to the yaml code.