### PR TITLE
Fix a typo in mobile platforms's q4

### DIFF
--- a/lectures/MobilePlatforms/exercises/Q4/ReadMe.md
+++ b/lectures/MobilePlatforms/exercises/Q4/ReadMe.md
@@ -178,5 +178,5 @@ so, you will need to:
    need to fetch the top stories from the API, and then fetch the corresponding items from the API.
    You will then need to map the hacker news items objects to `Story` objects, and expose them to
    the view using a `LiveData` object. You will need to transform the `List<Long>` returned by the
-   API into a `List<Story>`. You may use the `map` or `switchMap` transformations methods of
-   the `LiveData` class to do so.
+   API into a `List<Story>`. You may use the static `map` or `switchMap` methods of
+   the `Transformations` class to do so.


### PR DESCRIPTION
The handout asks to use the `map` or `switchMap` transformations methods of the `LiveData` class. This is a mistake since there is no `map`/`switchMap` methods on the `LiveData` class.

Note as well that those methods are static.

See [Android's LiveData documentation](https://developer.android.com/topic/libraries/architecture/livedata#livedata-in-architecture).

If I am mistaken, let me know.